### PR TITLE
add proguard-rules.pro for utility classes

### DIFF
--- a/utilities/proguard-rules.pro
+++ b/utilities/proguard-rules.pro
@@ -1,0 +1,56 @@
+# Add project specific ProGuard rules here.
+# You can control the set of applied configuration files using the
+# proguardFiles setting in build.gradle.
+#
+# For more details, see
+#   http://developer.android.com/guide/developing/tools/proguard.html
+
+# If your project uses WebView with JS, uncomment the following
+# and specify the fully qualified class name to the JavaScript interface
+# class:
+#-keepclassmembers class fqcn.of.javascript.interface.for.webview {
+#   public *;
+#}
+
+# Uncomment this to preserve the line number information for
+# debugging stack traces.
+#-keepattributes SourceFile,LineNumberTable
+
+# If you keep the line number information, uncomment this to
+# hide the original source file name.
+#-renamesourcefileattribute SourceFile
+
+
+##--------------- Begin: kotlinx.serialization ----------
+-keepattributes *Annotation*, InnerClasses
+-dontnote kotlinx.serialization.AnnotationsKt # core serialization annotations
+
+# kotlinx-serialization-json specific. Add this if you have java.lang.NoClassDefFoundError kotlinx.serialization.json.JsonObjectSerializer
+-keepclassmembers class kotlinx.serialization.*.** {
+    *** Companion;
+}
+-keepclasseswithmembers class kotlinx.serialization.*.** {
+    kotlinx.serialization.KSerializer serializer(...);
+}
+
+# Change here com.yourcompany.yourpackage
+-keep,includedescriptorclasses class com.suihan74.*.**$$serializer { *; } # <-- change package name to your app's
+-keepclassmembers class com.suihan74.*.** { # <-- change package name to your app's
+    *** Companion;
+}
+-keepclasseswithmembers class com.suihan74.*.** { # <-- change package name to your app's
+    kotlinx.serialization.KSerializer serializer(...);
+}
+##--------------- End: kotlinx.serialization ----------
+
+-keep class com.suihan74.utilities.BindingListAdapter { *; }
+-keep class com.suihan74.utilities.ViewModelFactory { *; }
+-keep class com.suihan74.utilities.dataBinding.** { *; }
+-keep class com.suihan74.utilities.extensions.ViewKt { *; }
+-keep class com.suihan74.utilities.dataBinding.ViewKt { *; }
+-keep class com.suihan74.utilities.fragment.AlertDialogFragment$Builder { *; }
+-keep class com.suihan74.utilities.fragment.AlertDialogFragment { *; }
+-keep class com.suihan74.utilities.serialization.LocalTimeSerializer { *; }
+-keep class com.suihan74.utilities.serialization.RectSerializer { *; }
+-keep class com.suihan74.utilities.view.UnFocusableEditText { *; }
+-keep class com.suihan74.utilities.view.UnFocusableTextInputEditText { *; }


### PR DESCRIPTION
This commit adds a `proguard-rules.pro` file to specify ProGuard rules for utility classes and `kotlinx.serialization`. This helps ensure that necessary classes and members are not removed during code optimization.